### PR TITLE
fix(protocol): player never stopped moving

### DIFF
--- a/client/input_handler.cpp
+++ b/client/input_handler.cpp
@@ -83,7 +83,7 @@ void InputHandler::send_direction() {
         if (was_moving) {
             // std::cout << "LOG: Enviando comando de fin de movimiento."
             //           << std::endl;
-            commands_queue.try_push(std::make_unique<StopMovingDTO>(dir));
+            commands_queue.try_push(std::make_unique<StopMovingDTO>());
             was_moving = false;
         }
     }

--- a/common/network/dto_constructor.h
+++ b/common/network/dto_constructor.h
@@ -13,13 +13,13 @@
 #include "common/network/dtos/snapshot_dto.h"
 #include "common/network/dtos/start_attacking_dto.h"
 #include "common/network/dtos/start_moving_dto.h"
+#include "common/network/dtos/stop_moving_dto.h"
 #include "common/network/protocol.h"
 
 using namespace DTOSerial::PlayerCommands;
 // using namespace DTOSerial:: otros;
 
 using DTOMaker = std::function<std::unique_ptr<DTO>(std::vector<uint8_t>&&)>;
-
 
 class DTOConstructor {
 private:
@@ -28,10 +28,24 @@ private:
 public:
     DTOConstructor() {
         maker_map = {
-            {MOVE, [](auto&& bytes) { return std::make_unique<StartMovingDTO>(std::move(bytes)); }},
-            {ATTACK, [](auto&& bytes) { return std::make_unique<StartAttackingDTO>(std::move(bytes)); }},
-            {SNAPSHOT, [](auto&& bytes) { return std::make_unique<SnapshotDTO>(std::move(bytes)); }},
-            // ...
+                {START_MOVING,
+                 [](auto&& bytes) {
+                     return std::make_unique<StartMovingDTO>(std::move(bytes));
+                 }},
+                {STOP_MOVING,
+                 [](auto&& bytes) {
+                     return std::make_unique<StopMovingDTO>(std::move(bytes));
+                 }},
+                {START_ATTACKING,
+                 [](auto&& bytes) {
+                     return std::make_unique<StartAttackingDTO>(
+                             std::move(bytes));
+                 }},
+                {SNAPSHOT,
+                 [](auto&& bytes) {
+                     return std::make_unique<SnapshotDTO>(std::move(bytes));
+                 }},
+                // ...
         };
     }
 
@@ -40,7 +54,7 @@ public:
             throw std::runtime_error("DTOConstructor error: unknown DTO type");
 
         DTOMaker f = maker_map.at(bytes[0]);
-        
+
         return f(std::move(bytes));
     }
 

--- a/common/network/dtos/start_attacking_dto.h
+++ b/common/network/dtos/start_attacking_dto.h
@@ -20,7 +20,7 @@ public:
         deserialize();
     }
 
-    StartAttackingDTO(): DTO(DTOSerial::PlayerCommands::ATTACK) {}
+    StartAttackingDTO(): DTO(DTOSerial::PlayerCommands::START_ATTACKING) {}
 
     void serialize_into(std::vector<uint8_t>& out) override {
         out.push_back(type);

--- a/common/network/dtos/start_moving_dto.h
+++ b/common/network/dtos/start_moving_dto.h
@@ -27,7 +27,7 @@ public:
     }
 
     explicit StartMovingDTO(const Direction& d):
-            DTO(DTOSerial::PlayerCommands::MOVE), dir(d) {}
+            DTO(DTOSerial::PlayerCommands::START_MOVING), dir(d) {}
 
     void serialize_into(std::vector<uint8_t>& out) override {
         out.push_back(type);

--- a/common/network/dtos/stop_attacking_dto.h
+++ b/common/network/dtos/stop_attacking_dto.h
@@ -8,9 +8,9 @@
 #include "common/network/dto.h"
 #include "common/network/protocol.h"
 
-
 class StopAttackingDTO: public DTO {
-    // TODO: Solo le cambie el nombre, no tiene logica, es una copia de start attacking
+    // TODO: Solo le cambie el nombre, no tiene logica, es una copia de start
+    // attacking
 private:
     friend class StartAttacking;
 
@@ -22,7 +22,7 @@ public:
         deserialize();
     }
 
-    StopAttackingDTO(): DTO(DTOSerial::PlayerCommands::ATTACK) {}
+    StopAttackingDTO(): DTO(DTOSerial::PlayerCommands::STOP_ATTACKING) {}
 
     void serialize_into(std::vector<uint8_t>& out) override {
         out.push_back(type);

--- a/common/network/dtos/stop_moving_dto.h
+++ b/common/network/dtos/stop_moving_dto.h
@@ -5,21 +5,16 @@
 #include <utility>
 #include <vector>
 
-#include "common/direction.h"
 #include "common/network/dto.h"
 #include "common/network/protocol.h"
 
 class StopMovingDTO: public DTO {
-    // TODO: Solo le cambie el nombre, no tiene logica, es una copia de start moving
+    // TODO: Solo le cambie el nombre, no tiene logica, es una copia de start
+    // moving
 private:
-    Direction dir;
+    friend class StopMoving;
 
-    friend class StartMoving;
-
-    void deserialize() override {
-        int i = 1;  // skip 1st byte (DTO type)
-        dir = deserialize_dir(i);
-    }
+    void deserialize() override {}
 
 public:
     explicit StopMovingDTO(std::vector<uint8_t>&& bytes):
@@ -27,15 +22,11 @@ public:
         deserialize();
     }
 
-    explicit StopMovingDTO(const Direction& d):
-            DTO(DTOSerial::PlayerCommands::MOVE), dir(d) {}
+    explicit StopMovingDTO(): DTO(DTOSerial::PlayerCommands::STOP_MOVING) {}
 
     void serialize_into(std::vector<uint8_t>& out) override {
         out.push_back(type);
-        serialize_dir_into(out, dir);
     }
-
-    Direction get_direction() { return dir; }
 
     ~StopMovingDTO() = default;
 };

--- a/common/network/protocol.h
+++ b/common/network/protocol.h
@@ -6,39 +6,41 @@
 #include "common/map_list.h"
 
 namespace Message {
-constexpr int LenBytes = 2; // vamos a mandar algo mas grande que 255 bytes?
-constexpr int MaxLen = 256; // <= 65535
+constexpr int LenBytes = 2;  // vamos a mandar algo mas grande que 255 bytes?
+constexpr int MaxLen = 256;  // <= 65535
 };  // namespace Message
 
 namespace LobbySerial {
-constexpr uint8_t CHANGE_USERNAME = 0x55; // U - 85
-constexpr uint8_t LIST_GAMES = 0x4C; // L - 76
-constexpr uint8_t CREATE_GAME = 0x43; // C - 67
-constexpr uint8_t JOIN_GAME = 0x4A; // J - 74
-constexpr uint8_t SUCCESS = 0x53; // S - 83
-constexpr uint8_t FAILURE = 0x46; // F - 70
-constexpr uint8_t EXIT_SERVER = 0x45; // E - 69
-}; // namespace LobbySerial
+constexpr uint8_t CHANGE_USERNAME = 0x55;  // U - 85
+constexpr uint8_t LIST_GAMES = 0x4C;       // L - 76
+constexpr uint8_t CREATE_GAME = 0x43;      // C - 67
+constexpr uint8_t JOIN_GAME = 0x4A;        // J - 74
+constexpr uint8_t SUCCESS = 0x53;          // S - 83
+constexpr uint8_t FAILURE = 0x46;          // F - 70
+constexpr uint8_t EXIT_SERVER = 0x45;      // E - 69
+};  // namespace LobbySerial
 
 namespace MapSerial {
 enum : uint8_t {
-    #define X(name) name,
-        MAP_LIST
-    #undef X
+#define X(name) name,
+    MAP_LIST
+#undef X
 };
-}; // namespace MapSerial
+};  // namespace MapSerial
 
 namespace DTOSerial {
-constexpr uint8_t GAME_DETAILS = 0x47; // G - 71
-    namespace PlayerCommands {
-    constexpr uint8_t AIM = 0xD7; // × - 215
-    constexpr uint8_t MOVE = 0x6D;    // m - 109
-    constexpr uint8_t ATTACK = 0x61;  // a - 97
-    constexpr uint8_t SNAPSHOT = 0x53; // S - 83
-    };  // namespace PlayerCommands
-    namespace GameState {
-        // TODO: Snapshot
-    }
+constexpr uint8_t GAME_DETAILS = 0x47;  // G - 71
+namespace PlayerCommands {
+constexpr uint8_t AIM = 0xD7;           // × - 215
+constexpr uint8_t START_MOVING = 0x6D;  // m - 109
+constexpr uint8_t STOP_MOVING = 0x6E;
+constexpr uint8_t START_ATTACKING = 0x61;  // a - 97
+constexpr uint8_t STOP_ATTACKING = 0x62;
+constexpr uint8_t SNAPSHOT = 0x53;  // S - 83
+};  // namespace PlayerCommands
+namespace GameState {
+// TODO: Snapshot
+}
 };  // namespace DTOSerial
 
 #endif

--- a/server/cmd_constructor.h
+++ b/server/cmd_constructor.h
@@ -9,10 +9,10 @@
 
 #include "common/network/dto.h"
 #include "common/network/protocol.h"
-#include "server/player_commands/aim.h"
 #include "server/player_commands/command.h"
 #include "server/player_commands/start_attacking.h"
 #include "server/player_commands/start_moving.h"
+#include "server/player_commands/stop_moving.h"
 
 using namespace DTOSerial::PlayerCommands;
 
@@ -26,10 +26,26 @@ private:
 public:
     CmdConstructor() {
         maker_map = {
-                {MOVE,
-                 [](auto&& dto_p) { return std::make_unique<StartMoving>(std::move(dto_p)); }},
-                {ATTACK,
-                 [](auto&& dto_p) { return std::make_unique<StartAttacking>(std::move(dto_p)); }},
+                /* {AIM,
+                 [](auto&& dto_p) {
+                     return std::make_unique<Aim>(std::move(dto_p));
+                 }}, */
+                {START_MOVING,
+                 [](auto&& dto_p) {
+                     return std::make_unique<StartMoving>(std::move(dto_p));
+                 }},
+                {STOP_MOVING,
+                 [](auto&& /* dto_p */) {
+                     return std::make_unique<StopMoving>();
+                 }},
+                {START_ATTACKING,
+                 [](auto&& dto_p) {
+                     return std::make_unique<StartAttacking>(std::move(dto_p));
+                 }},
+                /* {STOP_ATTACKING,
+                 [](auto&& dto_p) {
+                     return std::make_unique<StopAttacking>(std::move(dto_p));
+                 }}, */
                 // ...
         };
     }

--- a/server/game_setup.h
+++ b/server/game_setup.h
@@ -10,7 +10,7 @@
 #include "server/model/weapons.h"
 #include "server/player_handler.h"
 
-#define TICK_RATE 64
+#define TICK_RATE 20
 #define ROUNDS 15
 #define ROUND_TIME 600
 #define TIME_OUT 10

--- a/server/model/player.h
+++ b/server/model/player.h
@@ -1,6 +1,7 @@
 #ifndef SERVER_MODEL_PLAYER_H
 #define SERVER_MODEL_PLAYER_H
 
+#include <iostream>
 #include <memory>
 
 #include "common/direction.h"
@@ -92,7 +93,10 @@ public:
 
     virtual void start_moving(Direction dir) { physics.start_moving(dir); }
 
-    void stop_moving() { physics.stop_moving(); }
+    void stop_moving() {
+        std::cout << "Player: stop_moving();\n";
+        physics.stop_moving();
+    }
 
     virtual void start_attacking() {
         action = std::make_unique<Attack>(pos, dir, current,

--- a/server/model/player_physics.cpp
+++ b/server/model/player_physics.cpp
@@ -1,6 +1,7 @@
 #include "server/model/player_physics.h"
 
 #include <algorithm>
+#include <iostream>
 #include <numeric>
 #include <optional>
 #include <vector>
@@ -87,11 +88,13 @@ void PlayerPhysics::update(float dt) {
 }
 
 void PlayerPhysics::start_moving(const Direction& dir) {
+    std::cout << "PlayerPhysics: started moving\n";
     this->dir = dir;
     moving = true;
 }
 
 void PlayerPhysics::stop_moving() {
+    std::cout << "PlayerPhysics: stopped moving\n";
     v = 0;
     moving = false;
 }

--- a/server/player_commands/stop_moving.h
+++ b/server/player_commands/stop_moving.h
@@ -1,0 +1,20 @@
+#ifndef SERVER_PLAYER_COMMANDS_STOP_MOVING_H
+#define SERVER_PLAYER_COMMANDS_STOP_MOVING_H
+
+#include "common/network/dtos/stop_moving_dto.h"
+#include "server/model/player.h"
+#include "server/player_commands/command.h"
+
+/*
+ * Stop moving
+ * */
+class StopMoving: public Command {
+public:
+    explicit StopMoving() {}
+
+    void execute(Player& p) const override { p.stop_moving(); }
+
+    ~StopMoving() = default;
+};
+
+#endif

--- a/tests/client/mock_server.h
+++ b/tests/client/mock_server.h
@@ -20,7 +20,7 @@ using Duration = std::chrono::duration<float>;
 using Clock = std::chrono::steady_clock;
 using Ms = std::chrono::milliseconds;
 
-#define TICK_RATE 64
+#define TICK_RATE 20
 
 class Logger {
     static inline std::string secc = "<=========>\n";
@@ -55,10 +55,10 @@ private:
                                            std::make_unique<Knife>(), 0);
     };
     static inline float get_player_max_velocity() { return 50; }
-    static inline float get_player_acceleration() { return 10; }
-    static inline float get_player_radius() { return 1; }
+    static inline float get_player_acceleration() { return 20; }
+    static inline float get_player_radius() { return 10; }
     static inline int get_player_starting_money() { return 500; }
-    static inline int get_player_max_health() { return 1; }
+    static inline int get_player_max_health() { return 100; }
     static inline Position get_random_position() {
         return Position(Random::get(-100, 100), Random::get(-100, 100));
     }
@@ -126,7 +126,7 @@ public:
                 s.players.push_back(p->get_data());
             }
 
-            Logger::log(s);
+            // Logger::log(s);
 
             for (auto& h : handlers) {
                 h->send_snapshot(s);

--- a/tests/server/cmd_deserialization.cpp
+++ b/tests/server/cmd_deserialization.cpp
@@ -13,7 +13,7 @@
 
 namespace {
 TEST(CmdDeserializationTest, DeserializeValidMoveCommandNorth) {
-    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::MOVE,
+    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::START_MOVING,
                                       0x00,
                                       0x00,
                                       0x00,
@@ -33,7 +33,7 @@ TEST(CmdDeserializationTest, DeserializeValidMoveCommandNorth) {
 }
 
 TEST(CmdDeserializationTest, DeserializeValidMoveCommandNorthEast) {
-    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::MOVE,
+    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::START_MOVING,
                                       0x3f,
                                       0x35,
                                       0x04,
@@ -53,7 +53,7 @@ TEST(CmdDeserializationTest, DeserializeValidMoveCommandNorthEast) {
 }
 
 TEST(CmdDeserializationTest, DeserializeValidMoveCommandEast) {
-    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::MOVE,
+    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::START_MOVING,
                                       0x3f,
                                       0x80,
                                       0x00,
@@ -73,7 +73,7 @@ TEST(CmdDeserializationTest, DeserializeValidMoveCommandEast) {
 }
 
 TEST(CmdDeserializationTest, DeserializeValidMoveCommandSouthEast) {
-    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::MOVE,
+    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::START_MOVING,
                                       0x3f,
                                       0x35,
                                       0x04,
@@ -94,7 +94,7 @@ TEST(CmdDeserializationTest, DeserializeValidMoveCommandSouthEast) {
 }
 
 TEST(CmdDeserializationTest, DeserializeValidMoveCommandSouth) {
-    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::MOVE,
+    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::START_MOVING,
                                       0x00,
                                       0x00,
                                       0x00,
@@ -114,7 +114,7 @@ TEST(CmdDeserializationTest, DeserializeValidMoveCommandSouth) {
 }
 
 TEST(CmdDeserializationTest, DeserializeValidMoveCommandSouthWest) {
-    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::MOVE,
+    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::START_MOVING,
                                       0xbf,
                                       0x35,
                                       0x04,
@@ -135,7 +135,7 @@ TEST(CmdDeserializationTest, DeserializeValidMoveCommandSouthWest) {
 }
 
 TEST(CmdDeserializationTest, DeserializeValidMoveCommandWest) {
-    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::MOVE,
+    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::START_MOVING,
                                       0xbf,
                                       0x80,
                                       0x00,
@@ -155,7 +155,7 @@ TEST(CmdDeserializationTest, DeserializeValidMoveCommandWest) {
 }
 
 TEST(CmdDeserializationTest, DeserializeValidMoveCommandNorthWest) {
-    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::MOVE,
+    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::START_MOVING,
                                       0xbf,
                                       0x35,
                                       0x04,
@@ -176,15 +176,16 @@ TEST(CmdDeserializationTest, DeserializeValidMoveCommandNorthWest) {
 }
 
 TEST(CmdDeserializationTest, DeserializeValidAttackCommandWithPositionXPiYPi) {
-    std::vector<uint8_t> srlzd_cmd = {DTOSerial::PlayerCommands::ATTACK,
-                                      0x40,
-                                      0x49,
-                                      0x0f,
-                                      0xdb,  // ~pi
-                                      0x40,
-                                      0x49,
-                                      0x0f,
-                                      0xdb};  // ~pi
+    std::vector<uint8_t> srlzd_cmd = {
+            DTOSerial::PlayerCommands::START_ATTACKING,
+            0x40,
+            0x49,
+            0x0f,
+            0xdb,  // ~pi
+            0x40,
+            0x49,
+            0x0f,
+            0xdb};  // ~pi
     std::vector<uint8_t> bytes = srlzd_cmd;
     std::unique_ptr<DTO> dto_p =
             std::make_unique<StartAttackingDTO>(std::move(bytes));

--- a/tests/server/serialization.cpp
+++ b/tests/server/serialization.cpp
@@ -8,119 +8,128 @@
 
 namespace {
 TEST(SerializationTest, SerializeMoveCommandNorth) {
-    std::vector<uint8_t> expected_srl = {DTOSerial::PlayerCommands::MOVE,
-                                         0x00,
-                                         0x00,
-                                         0x00,
-                                         0x00,  // 0
-                                         0x3f,
-                                         0x80,
-                                         0x00,
-                                         0x00};  // 1
+    std::vector<uint8_t> expected_srl = {
+            DTOSerial::PlayerCommands::START_MOVING,
+            0x00,
+            0x00,
+            0x00,
+            0x00,  // 0
+            0x3f,
+            0x80,
+            0x00,
+            0x00};  // 1
     StartMovingDTO dto = StartMovingDTO(Direction(0, 1));
     EXPECT_EQ(dto.serialize(), expected_srl);
 }
 
 TEST(SerializationTest, SerializeMoveCommandNorthEast) {
-    std::vector<uint8_t> expected_srl = {DTOSerial::PlayerCommands::MOVE,
-                                         0x3f,
-                                         0x35,
-                                         0x04,
-                                         0xf3,  // 1/sqrt(2)
-                                         0x3f,
-                                         0x35,
-                                         0x04,
-                                         0xf3};  // 1/sqrt(2)
+    std::vector<uint8_t> expected_srl = {
+            DTOSerial::PlayerCommands::START_MOVING,
+            0x3f,
+            0x35,
+            0x04,
+            0xf3,  // 1/sqrt(2)
+            0x3f,
+            0x35,
+            0x04,
+            0xf3};  // 1/sqrt(2)
     StartMovingDTO dto = StartMovingDTO(Direction(1, 1));
     EXPECT_EQ(dto.serialize(), expected_srl);
 }
 
 TEST(SerializationTest, SerializeMoveCommandEast) {
-    std::vector<uint8_t> expected_srl = {DTOSerial::PlayerCommands::MOVE,
-                                         0x3f,
-                                         0x80,
-                                         0x00,
-                                         0x00,  // 1
-                                         0x00,
-                                         0x00,
-                                         0x00,
-                                         0x00};  // 0
+    std::vector<uint8_t> expected_srl = {
+            DTOSerial::PlayerCommands::START_MOVING,
+            0x3f,
+            0x80,
+            0x00,
+            0x00,  // 1
+            0x00,
+            0x00,
+            0x00,
+            0x00};  // 0
     StartMovingDTO dto = StartMovingDTO(Direction(1, 0));
     EXPECT_EQ(dto.serialize(), expected_srl);
 }
 
 TEST(SerializationTest, SerializeMoveCommandSouthEast) {
-    std::vector<uint8_t> expected_srl = {DTOSerial::PlayerCommands::MOVE,
-                                         0x3f,
-                                         0x35,
-                                         0x04,
-                                         0xf3,  // 1/sqrt(2)
-                                         0xbf,
-                                         0x35,
-                                         0x04,
-                                         0xf3};  // -1/sqrt(2)
+    std::vector<uint8_t> expected_srl = {
+            DTOSerial::PlayerCommands::START_MOVING,
+            0x3f,
+            0x35,
+            0x04,
+            0xf3,  // 1/sqrt(2)
+            0xbf,
+            0x35,
+            0x04,
+            0xf3};  // -1/sqrt(2)
     StartMovingDTO dto = StartMovingDTO(Direction(1, -1));
     EXPECT_EQ(dto.serialize(), expected_srl);
 }
 
 TEST(SerializationTest, SerializeMoveCommandSouth) {
-    std::vector<uint8_t> expected_srl = {DTOSerial::PlayerCommands::MOVE,
-                                         0x00,
-                                         0x00,
-                                         0x00,
-                                         0x00,  // 0
-                                         0xbf,
-                                         0x80,
-                                         0x00,
-                                         0x00};  // -1
+    std::vector<uint8_t> expected_srl = {
+            DTOSerial::PlayerCommands::START_MOVING,
+            0x00,
+            0x00,
+            0x00,
+            0x00,  // 0
+            0xbf,
+            0x80,
+            0x00,
+            0x00};  // -1
     StartMovingDTO dto = StartMovingDTO(Direction(0, -1));
     EXPECT_EQ(dto.serialize(), expected_srl);
 }
 
 TEST(SerializationTest, SerializeMoveCommandSouthWest) {
-    std::vector<uint8_t> expected_srl = {DTOSerial::PlayerCommands::MOVE,
-                                         0xbf,
-                                         0x35,
-                                         0x04,
-                                         0xf3,  // -1/sqrt(2)
-                                         0xbf,
-                                         0x35,
-                                         0x04,
-                                         0xf3};  // -1/sqrt(2)
+    std::vector<uint8_t> expected_srl = {
+            DTOSerial::PlayerCommands::START_MOVING,
+            0xbf,
+            0x35,
+            0x04,
+            0xf3,  // -1/sqrt(2)
+            0xbf,
+            0x35,
+            0x04,
+            0xf3};  // -1/sqrt(2)
     StartMovingDTO dto = StartMovingDTO(Direction(-1, -1));
     EXPECT_EQ(dto.serialize(), expected_srl);
 }
 
 TEST(SerializationTest, SerializeMoveCommandWest) {
-    std::vector<uint8_t> expected_srl = {DTOSerial::PlayerCommands::MOVE,
-                                         0xbf,
-                                         0x80,
-                                         0x00,
-                                         0x00,  // -1
-                                         0x00,
-                                         0x00,
-                                         0x00,
-                                         0x00};  // 0
+    std::vector<uint8_t> expected_srl = {
+            DTOSerial::PlayerCommands::START_MOVING,
+            0xbf,
+            0x80,
+            0x00,
+            0x00,  // -1
+            0x00,
+            0x00,
+            0x00,
+            0x00};  // 0
     StartMovingDTO dto = StartMovingDTO(Direction(-1, 0));
     EXPECT_EQ(dto.serialize(), expected_srl);
 }
 
 TEST(SerializationTest, SerializeMoveCommandNorthWest) {
-    std::vector<uint8_t> expected_srl = {DTOSerial::PlayerCommands::MOVE,
-                                         0xbf,
-                                         0x35,
-                                         0x04,
-                                         0xf3,  // -1/sqrt(2)
-                                         0x3f,
-                                         0x35,
-                                         0x04,
-                                         0xf3};  // 1/sqrt(2)
+    std::vector<uint8_t> expected_srl = {
+            DTOSerial::PlayerCommands::START_MOVING,
+            0xbf,
+            0x35,
+            0x04,
+            0xf3,  // -1/sqrt(2)
+            0x3f,
+            0x35,
+            0x04,
+            0xf3};  // 1/sqrt(2)
     StartMovingDTO dto = StartMovingDTO(Direction(-1, 1));
     EXPECT_EQ(dto.serialize(), expected_srl);
 }
 
 TEST(SerializationTest, SerializeAttackCommandWithPositionXPiYPi) {
-    std::vector<uint8_t> expected_srl = {DTOSerial::PlayerCommands::ATTACK};
+    std::vector<uint8_t> expected_srl = {
+            DTOSerial::PlayerCommands::START_ATTACKING};
     StartAttackingDTO dto = StartAttackingDTO();
     EXPECT_EQ(dto.serialize(), expected_srl);
 }


### PR DESCRIPTION
El comando StopMoving tiene que existir si vamos a usar comandos pasivos, porque hay lógica secundaria además del simple cambio del simple cambio de dirección en Player::stop_moving()
- Implementar StopMoving, StopMovingDTO
- Implementar el envío y recibo del nuevo dto
- Usar las clases en el código existente

Closes #73 